### PR TITLE
Add codeblock formatting to copied stat block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ Media/PGNs/*
 Media/Networks/*
 Media/Events/*
 
+venv/*
+.idea/*
+
 *.lock
 *.epd

--- a/OpenBench/static/copy_text.js
+++ b/OpenBench/static/copy_text.js
@@ -22,3 +22,27 @@ function copy_text(element_id, keep_url) {
         console.error("Unable to copy to Clipboard");
     }
 }
+
+function copy_text_codeblock(element_id, keep_url) {
+    var text = document.getElementById(element_id).innerHTML;
+    text = text.replace(/<br>/g, "\n");
+    text = ["```", text, "```"].join("\n")
+
+    if (keep_url)
+        text += "\n" + window.location.href;
+
+    var area = document.createElement("textarea");
+    area.value = text;
+    document.body.append(area);
+    area.select();
+
+    try {
+        document.execCommand("copy");
+        document.body.removeChild(area);
+    }
+
+    catch (err) {
+        document.body.removeChild(area);
+        console.error("Unable to copy to Clipboard");
+    }
+}

--- a/OpenBench/templatetags/mytags.py
+++ b/OpenBench/templatetags/mytags.py
@@ -111,7 +111,6 @@ def longStatBlock(test):
 
     if test.use_penta:
         lines.append('Penta | [%d, %d, %d, %d, %d]' % test.as_penta())
-
     return '\n'.join(lines)
 
 def testResultColour(test):

--- a/Templates/OpenBench/workload.html
+++ b/Templates/OpenBench/workload.html
@@ -118,7 +118,7 @@
         <!-- Copy Button: Copy the current results statblock -->
         {% if type == "TEST" or type == "DATAGEN" %}
             <div class="anchor-container">
-                <a class="mt-1 anchorbutton btn-blue" onclick="copy_text('long-statblock', true)">Copy Stat Block</a>
+                <a class="mt-1 anchorbutton btn-blue" onclick="copy_text_codeblock('long-statblock', true)">Copy Stat Block</a>
             </div>
         {% endif %}
 


### PR DESCRIPTION
This changes the 'Copy Stat Block' button so that it includes triple backticks for formatting on Discord. Here is what it looks like for a standard SPRT:

```
Elo   | 0.00 +- 0.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 0.00 (-2.94, 2.94) [0.00, 3.00]
Games | N: 0 W: 0 L: 0 D: 0
Penta | [0, 0, 0, 0, 0]
```
http://localhost:8000/test/1/

I tested and verified these changes locally.